### PR TITLE
add nvim lua config files

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,0 +1,19 @@
+local set = vim.opt
+
+set.number = true
+set.relativenumber = true
+
+set.incsearch = true
+set.hlsearch = true  -- highlight search
+
+set.modifiable = true
+
+-- tabs
+set.tabstop= 2
+set.shiftwidth= 2
+set.softtabstop= 2
+set.expandtab = true
+
+require('brunocroh.settings')
+require('brunocroh.plugins')
+require('brunocroh.keybinds')

--- a/nvim/lua/brunocroh/keybinds.lua
+++ b/nvim/lua/brunocroh/keybinds.lua
@@ -1,0 +1,3 @@
+local function map(m, k, v)
+    vim.keymap.set(m, k, v, { silent = true })
+end

--- a/nvim/lua/brunocroh/plugins.lua
+++ b/nvim/lua/brunocroh/plugins.lua
@@ -1,0 +1,170 @@
+-- Automatically run :PackerCompile whenever plugins.lua is updated with an autocommand:
+vim.api.nvim_create_autocmd('BufWritePost', {
+  group = vim.api.nvim_create_augroup('PACKER', { clear = true }),
+  pattern = 'plugins.lua',
+  command = 'source <afile> | PackerCompile',
+})
+
+return require('packer').startup(function(use)
+  use 'wbthomason/packer.nvim'
+
+
+  use 'nvim-lua/plenary.nviM'
+
+  -- Visual --
+  use 'morhetz/gruvbox'
+  use({
+    'nvim-lualine/lualine.nvim',
+    config = function()
+      require('brunocroh.plugins.lualine')   
+    end,
+  })
+
+  -- File Manger --
+  use({
+    'nvim-tree/nvim-tree.lua',
+    requires = {
+      'nvim-tree/nvim-web-devicons', -- file icons
+    },
+    config = function()
+      require('brunocroh.plugins.nvim-tree')
+    end,
+  })
+
+  -- Syntax --
+  use({
+    {
+      'nvim-treesitter/nvim-treesitter',
+      event = 'CursorHold',
+      run = ':TSUpdate',
+      config = function()
+        require('brunocroh.plugins.treesitter')
+      end,
+    },
+    { 'windwp/nvim-ts-autotag', after = 'nvim-treesitter' },
+  })
+
+  -- Fuzzy --
+  use({
+    {
+      'nvim-telescope/telescope.nvim',
+      event = 'CursorHold',
+      config = function()
+        require('brunocroh.plugins.telescope')
+      end,
+    },
+    {
+      'nvim-telescope/telescope-fzf-native.nvim',
+      after = 'telescope.nvim',
+      run = 'make',
+      config = function()
+        require('telescope').load_extension('fzf')
+      end,
+    },
+    {
+      'nvim-telescope/telescope-symbols.nvim',
+      after = 'telescope.nvim',
+    },
+  })
+
+  -- Code completion --
+  use({
+    'mattn/emmet-vim',
+    setup = function()
+      vim.g.user_emmet_leader_key = ','
+      vim.g.user_emmet_settings = {
+        indent_blockelement = 1,
+      }
+    end,
+  })
+  use 'tpope/vim-surround'
+  use {
+    'haorenW1025/completion-nvim',
+    opt = true,
+    requires = {{'hrsh7th/vim-vsnip', opt = true}, {'hrsh7th/vim-vsnip-integ', opt = true}}
+  }
+
+  -- LSP --
+  use({
+    'neovim/nvim-lspconfig',
+    event = 'BufRead',
+    config = function()
+      require('brunocroh.plugins.lsp.servers')
+    end,
+    requires = {
+      {
+        -- WARN: Unfortunately we won't be able to lazy load this
+        'hrsh7th/cmp-nvim-lsp',
+      },
+    },
+  })
+
+  use({
+    {
+      'hrsh7th/nvim-cmp',
+      event = 'InsertEnter',
+      config = function()
+        require('brunocroh.plugins.lsp.nvim-cmp')
+      end,
+      requires = {
+        {
+          'L3MON4D3/LuaSnip',
+          event = 'InsertEnter',
+          config = function()
+            require('brunocroh.plugins.lsp.luasnip')
+          end,
+          requires = {
+            {
+              'rafamadriz/friendly-snippets',
+              event = 'CursorHold',
+            },
+          },
+        },
+      },
+    },
+    { 'saadparwaiz1/cmp_luasnip', after = 'nvim-cmp' },
+    { 'hrsh7th/cmp-path', after = 'nvim-cmp' },
+    { 'hrsh7th/cmp-buffer', after = 'nvim-cmp' },
+  })
+
+  use({
+    'jose-elias-alvarez/null-ls.nvim',
+    event = 'BufRead',
+    config = function()
+      require('brunocroh.plugins.lsp.null-ls')
+    end,
+  })
+
+  use({
+    'windwp/nvim-autopairs',
+    event = 'InsertCharPre',
+    after = 'nvim-cmp',
+    config = function()
+      require('brunocroh.plugins.pairs')
+    end,
+  })
+
+
+  use({
+    'williamboman/mason.nvim',
+    config = function()
+      require('brunocroh.plugins.mason')
+    end
+  })
+
+  use({
+    'williamboman/mason-lspconfig.nvim',
+    config = function()
+      require('brunocroh.plugins.mason-lspconfig')
+    end
+  })
+
+  use({
+    'j-hui/fidget.nvim',
+    config = function()
+      require('brunocroh.plugins.fidget')
+    end
+  })
+
+end)
+

--- a/nvim/lua/brunocroh/plugins/fidget.lua
+++ b/nvim/lua/brunocroh/plugins/fidget.lua
@@ -1,0 +1,1 @@
+require('fidget').setup()

--- a/nvim/lua/brunocroh/plugins/lsp/luasnip.lua
+++ b/nvim/lua/brunocroh/plugins/lsp/luasnip.lua
@@ -1,0 +1,26 @@
+local types = require('luasnip.util.types')
+
+require('luasnip').setup({
+    ext_opts = {
+        [types.choiceNode] = {
+            active = {
+                virt_text = { { '●', 'DiffAdd' } },
+            },
+        },
+        [types.insertNode] = {
+            active = {
+                virt_text = { { '●', 'DiffDelete' } },
+            },
+        },
+    },
+})
+
+-- Loading any vscode snippets from plugins
+require('luasnip.loaders.from_vscode').lazy_load()
+
+-- Allow jsx and tsx to use js snippets
+require('luasnip').filetype_extend('javascript', { 'javascriptreact', 'typescriptreact' })
+
+-- Mappins to move around inside snippets
+vim.keymap.set({ 'i', 's' }, '<C-j>', '<CMD>lua require("luasnip").jump(1)<CR>')
+vim.keymap.set({ 'i', 's' }, '<C-k>', '<CMD>lua require("luasnip").jump(-1)<CR>')

--- a/nvim/lua/brunocroh/plugins/lsp/null-ls.lua
+++ b/nvim/lua/brunocroh/plugins/lsp/null-ls.lua
@@ -1,0 +1,55 @@
+local nls = require('null-ls')
+local U = require('brunocroh.plugins.lsp.utils')
+
+local fmt = nls.builtins.formatting
+local dgn = nls.builtins.diagnostics
+local cda = nls.builtins.code_actions
+
+-- Configuring null-ls
+nls.setup({
+    sources = {
+        ----------------
+        -- FORMATTING --
+        ----------------
+        fmt.trim_whitespace.with({
+            filetypes = { 'text', 'zsh', 'toml', 'make', 'conf', 'tmux' },
+        }),
+        -- NOTE:
+        -- 1. both needs to be enabled to so prettier can apply eslint fixes
+        -- 2. prettierd should come first to prevent occassional race condition
+        fmt.prettierd,
+        fmt.eslint_d,
+        -- fmt.prettier.with({
+        --     extra_args = {
+        --         '--tab-width=4',
+        --         '--trailing-comma=es5',
+        --         '--end-of-line=lf',
+        --         '--arrow-parens=always',
+        --     },
+        -- }),
+        fmt.rustfmt,
+        fmt.stylua,
+        fmt.gofmt,
+        fmt.zigfmt,
+        fmt.shfmt.with({
+            extra_args = { '-i', 4, '-ci', '-sr' },
+        }),
+        -----------------
+        -- DIAGNOSTICS --
+        -----------------
+        dgn.eslint_d,
+        dgn.shellcheck,
+        dgn.luacheck.with({
+            extra_args = { '--globals', 'vim', '--std', 'luajit' },
+        }),
+        ------------------
+        -- CODE ACTIONS --
+        ------------------
+        cda.eslint_d,
+        cda.shellcheck,
+    },
+    on_attach = function(client, bufnr)
+        U.fmt_on_save(client, bufnr)
+        U.mappings(bufnr)
+    end,
+})

--- a/nvim/lua/brunocroh/plugins/lsp/nvim-cmp.lua
+++ b/nvim/lua/brunocroh/plugins/lsp/nvim-cmp.lua
@@ -1,0 +1,67 @@
+local cmp = require('cmp')
+
+local icons = {
+    Text = '',
+    Method = '',
+    Function = '',
+    Constructor = '',
+    Field = 'ﰠ',
+    Variable = '',
+    Class = 'ﴯ',
+    Interface = '',
+    Module = '',
+    Property = 'ﰠ',
+    Unit = '塞',
+    Value = '',
+    Enum = '',
+    Keyword = '',
+    Snippet = '',
+    Color = '',
+    File = '',
+    Reference = '',
+    Folder = '',
+    EnumMember = '',
+    Constant = '',
+    Struct = 'פּ',
+    Event = '',
+    Operator = '',
+    TypeParameter = '',
+}
+
+local aliases = {
+    nvim_lsp = 'lsp',
+    luasnip = 'snippet',
+}
+
+cmp.setup({
+  mapping = cmp.mapping.preset.insert({
+    ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+    ['<C-f>'] = cmp.mapping.scroll_docs(4),
+    ['<C-Space>'] = cmp.mapping.complete(),
+    ['<C-e>'] = cmp.mapping.close(),
+    ['<CR>'] = cmp.mapping.confirm({
+      behavior = cmp.ConfirmBehavior.Replace,
+      select = true
+    }),
+  }),
+  sources = cmp.config.sources({
+        { name = 'nvim_lsp', max_item_count = 10 },
+        { name = 'luasnip', max_item_count = 10 },
+        { name = 'path', max_item_count = 10 },
+        { name = 'buffer', max_item_count = 10 },
+    }),
+    snippet = {
+        expand = function(args)
+            require('luasnip').lsp_expand(args.body)
+        end,
+    },
+    formatting = {
+        format = function(entry, item)
+            -- Kind icons
+            item.kind = string.format('%s %s', icons[item.kind], item.kind)
+            -- Source
+            item.menu = string.format('[%s]', aliases[entry.source.name] or entry.source.name)
+            return item
+        end,
+    },
+})

--- a/nvim/lua/brunocroh/plugins/lsp/servers.lua
+++ b/nvim/lua/brunocroh/plugins/lsp/servers.lua
@@ -1,0 +1,135 @@
+local lsp = require('lspconfig')
+local U = require('brunocroh.plugins.lsp.utils')
+
+---Common perf related flags for all the LSP servers
+local flags = {
+    allow_incremental_sync = true,
+    debounce_text_changes = 200,
+}
+
+---Common capabilities including lsp snippets and autocompletion
+local capabilities = U.capabilities()
+
+---Common `on_attach` function for LSP servers
+---@param client table
+---@param buf integer
+local function on_attach(client, buf)
+    U.disable_formatting(client)
+    U.mappings(buf)
+end
+
+-- Disable LSP logging
+vim.lsp.set_log_level(vim.lsp.log_levels.OFF)
+
+-- Configuring native diagnostics
+vim.diagnostic.config({
+    virtual_text = {
+        source = 'always',
+    },
+    float = {
+        source = 'always',
+    },
+})
+
+-- Lua
+lsp.sumneko_lua.setup({
+    flags = flags,
+    capabilities = capabilities,
+    on_attach = on_attach,
+    settings = {
+        Lua = {
+            completion = {
+                enable = true,
+                showWord = 'Disable',
+                -- keywordSnippet = 'Disable',
+            },
+            runtime = {
+                -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
+                version = 'LuaJIT',
+            },
+            diagnostics = {
+                globals = { 'vim' },
+            },
+            workspace = {
+                -- Make the server aware of Neovim runtime files
+                library = { os.getenv('VIMRUNTIME') },
+            },
+            -- Do not send telemetry data containing a randomized but unique identifier
+            telemetry = {
+                enable = false,
+            },
+        },
+    },
+})
+
+-- Rust
+lsp.rust_analyzer.setup({
+    flags = flags,
+    capabilities = capabilities,
+    on_attach = on_attach,
+    settings = {
+        ['rust-analyzer'] = {
+            cargo = {
+                allFeatures = true,
+            },
+            checkOnSave = {
+                allFeatures = true,
+                command = 'clippy',
+            },
+            procMacro = {
+                ignored = {
+                    ['async-trait'] = { 'async_trait' },
+                    ['napi-derive'] = { 'napi' },
+                    ['async-recursion'] = { 'async_recursion' },
+                },
+            },
+        },
+    },
+})
+
+-- Angular
+-- 1. install @angular/language-server globally
+-- 2. install @angular/language-service inside project as dev dep
+lsp.angularls.setup({
+    flags = flags,
+    capabilities = capabilities,
+    on_attach = function(client, buf)
+        client.server_capabilities.renameProvider = false
+        on_attach(client, buf)
+    end,
+})
+
+---List of the LSP server that don't need special configuration
+local servers = {
+    'zls', -- Zig
+    'gopls', -- Golang
+    'tsserver', -- Typescript
+    'html', -- HTML
+    'cssls', -- CSS
+    'jsonls', -- Json
+    'yamlls', -- YAML
+    'emmet_ls', -- emmet-ls
+    -- 'terraformls', -- Terraform
+}
+
+for _, server in ipairs(servers) do
+    lsp[server].setup({
+        flags = flags,
+        capabilities = capabilities,
+        on_attach = on_attach,
+    })
+end
+
+-- NOTE: Using `eslint_d` via `null-ls` bcz it is way fasterrrrrrr.
+-- Eslint
+--[[ lsp.eslint.setup({
+    flags = flags,
+    capabilities = capabilities,
+    on_attach = on_attach,
+    settings = {
+        useESLintClass = true, -- Recommended for eslint >= 7
+        run = 'onSave', -- Run `eslint` after save
+    },
+    -- NOTE: `root_dir` is required to fix the monorepo issue
+    root_dir = require('lspconfig.util').find_git_ancestor,
+}) ]]

--- a/nvim/lua/brunocroh/plugins/lsp/utils.lua
+++ b/nvim/lua/brunocroh/plugins/lsp/utils.lua
@@ -1,0 +1,66 @@
+local map = vim.keymap.set
+
+local U = {}
+
+local fmt_group = vim.api.nvim_create_augroup('FORMATTING', { clear = true })
+
+---Common format-on-save for lsp servers that implements formatting
+---@param client table
+---@param buf integer
+function U.fmt_on_save(client, buf)
+    if client.supports_method('textDocument/formatting') then
+        vim.api.nvim_create_autocmd('BufWritePre', {
+            group = fmt_group,
+            buffer = buf,
+            callback = function()
+                vim.lsp.buf.format({
+                    timeout_ms = 3000,
+                    buffer = buf,
+                })
+            end,
+        })
+    end
+end
+
+---LSP servers capabilities w/ nvim-cmp
+function U.capabilities()
+    -- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..
+    local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+    return require('cmp_nvim_lsp').default_capabilities(capabilities)
+end
+
+---Disable formatting for servers | Handled by null-ls
+---@param client table
+---@see https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Avoiding-LSP-formatting-conflicts
+function U.disable_formatting(client)
+    client.server_capabilities.documentFormattingProvider = false
+    client.server_capabilities.documentRangeFormattingProvider = true
+end
+
+---Creates LSP mappings
+---@param buf number
+function U.mappings(buf)
+    local opts = { buffer = buf }
+
+    map('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<CR>', opts)
+    map('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts)
+    map('n', 'gh', '<cmd>lua vim.lsp.buf.hover()<CR>', opts)
+    map('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+    map('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+    map('i', '<C-h>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
+    -- map('n', '<leader>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
+    -- map('n', '<leader>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
+    -- map('n', '<leader>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
+    -- map('n', '<leader>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
+    map('n', '<leader>r', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+    map('n', '<leader>c', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+    -- map('v', '<leader>ca', '<cmd>lua vim.lsp.buf.range_code_action()<CR>', opts)
+    map('n', '<leader>e', '<cmd>lua vim.diagnostic.open_float()<CR>', opts)
+    map('n', '[g', '<cmd>lua vim.diagnostic.goto_prev()<CR>', opts)
+    map('n', ']g', '<cmd>lua vim.diagnostic.goto_next()<CR>', opts)
+    -- map('n', '<leader>q', '<cmd>lua vim.diagnostic.setloclist()<CR>', opts)
+    -- map('n', '<leader>so', [[<cmd>lua require('telescope.builtin').lsp_document_symbols()<CR>]], opts)
+end
+
+return U

--- a/nvim/lua/brunocroh/plugins/lualine.lua
+++ b/nvim/lua/brunocroh/plugins/lualine.lua
@@ -1,0 +1,41 @@
+-- Bubbles config for lualine
+-- Author: lokesh-krishna
+-- MIT license, see LICENSE for more details.
+
+-- stylua: ignore
+require('lualine').setup {
+  options = {
+    icons_enabled = true,
+    theme = 'gruvbox_dark',
+    component_separators = { left = '', right = ''},
+    section_separators = { left = '', right = ''},
+    ignore_focus = {},
+    always_divide_middle = true,
+    globalstatus = false,
+    refresh = {
+      statusline = 1000,
+      tabline = 1000,
+      winbar = 1000,
+    }
+  },
+  sections = {
+    lualine_a = {'mode'},
+    lualine_b = {'branch', 'diff', 'diagnostics'},
+    lualine_c = {'filename'},
+    lualine_x = {'encoding', 'fileformat', 'filetype'},
+    lualine_y = {'progress'},
+    lualine_z = {'location'}
+  },
+  inactive_sections = {
+    lualine_a = {},
+    lualine_b = {},
+    lualine_c = {'filename'},
+    lualine_x = {'location'},
+    lualine_y = {},
+    lualine_z = {}
+  },
+  tabline = {},
+  winbar = {},
+  inactive_winbar = {},
+  extensions = {}
+}

--- a/nvim/lua/brunocroh/plugins/mason-lspconfig.lua
+++ b/nvim/lua/brunocroh/plugins/mason-lspconfig.lua
@@ -1,0 +1,1 @@
+require('mason-lspconfig').setup()

--- a/nvim/lua/brunocroh/plugins/mason.lua
+++ b/nvim/lua/brunocroh/plugins/mason.lua
@@ -1,0 +1,9 @@
+require('mason').setup({
+  ui = {
+    icons = {
+      package_installed = "✓",
+      package_pending = "➜",
+      package_uninstalled = "✗"
+    }
+  }
+})

--- a/nvim/lua/brunocroh/plugins/nvim-tree.lua
+++ b/nvim/lua/brunocroh/plugins/nvim-tree.lua
@@ -1,0 +1,63 @@
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+require('nvim-tree').setup({
+  diagnostics = {
+    enable = true,
+  },
+  update_focused_file = {
+    enable = true,
+  },
+  view = {
+    adaptive_size = true,
+    side = 'left',
+  },
+  filters = {
+    custom = { '.git$', 'node_modules$', '^target$' },
+  },
+  git = {
+    ignore = false,
+  },
+  actions = {
+    open_file = {
+      window_picker = {
+        enable = false,
+      },
+    },
+  },
+  open_on_setup = true,
+  renderer = {
+    icons = {
+      show = {
+        git = true,
+        folder = true,
+        file = true,
+        folder_arrow = false,
+      },
+      glyphs = {
+        default = '',
+        git = {
+          unstaged = '~',
+          staged = '+',
+          unmerged = '!',
+          renamed = '≈',
+          untracked = '?',
+          deleted = '-',
+        },
+      },
+    },
+    indent_markers = {
+      enable = true,
+    },
+  },
+})
+
+vim.keymap.set('n', '<F4>', '<CMD>NvimTreeToggle<CR>')
+
+vim.api.nvim_create_autocmd('FileType', {
+  group = vim.api.nvim_create_augroup('NVIM_TREE', { clear = true }),
+  pattern = 'NvimTree',
+  callback = function()
+    vim.api.nvim_win_set_option(0, 'wrap', false)
+  end,
+})

--- a/nvim/lua/brunocroh/plugins/pairs.lua
+++ b/nvim/lua/brunocroh/plugins/pairs.lua
@@ -1,0 +1,4 @@
+require('nvim-autopairs').setup()
+
+-- Integration w/ nvim-cmp
+require('cmp').event:on('confirm_done', require('nvim-autopairs.completion.cmp').on_confirm_done())

--- a/nvim/lua/brunocroh/plugins/telescope.lua
+++ b/nvim/lua/brunocroh/plugins/telescope.lua
@@ -1,0 +1,60 @@
+local actions = require('telescope.actions')
+local finders = require('telescope.builtin')
+
+require('telescope').setup({
+    defaults = {
+        prompt_prefix = ' ❯ ',
+        initial_mode = 'insert',
+        sorting_strategy = 'ascending',
+        layout_config = {
+            prompt_position = 'top',
+        },
+        mappings = {
+            i = {
+                ['<ESC>'] = actions.close,
+                ['<C-j>'] = actions.move_selection_next,
+                ['<C-k>'] = actions.move_selection_previous,
+                ['<TAB>'] = actions.toggle_selection + actions.move_selection_next,
+                ['<C-s>'] = actions.send_selected_to_qflist,
+                ['<C-q>'] = actions.send_to_qflist,
+            },
+        },
+    },
+    extensions = {
+        fzf = {
+            fuzzy = true,
+            override_generic_sorter = true, -- override the generic sorter
+            override_file_sorter = true, -- override the file sorter
+            case_mode = 'smart_case', -- "smart_case" | "ignore_case" | "respect_case"
+        },
+    },
+})
+
+local Telescope = setmetatable({}, {
+    __index = function(_, k)
+        if vim.bo.filetype == 'NvimTree' then
+            vim.cmd.wincmd('l')
+        end
+        return finders[k]
+    end,
+})
+
+-- Ctrl-p = fuzzy finder
+vim.keymap.set('n', '<C-P>', function()
+    local ok = pcall(Telescope.git_files, { show_untracked = true })
+    if not ok then
+        Telescope.find_files()
+    end
+end)
+
+-- Get :help at the speed of light
+vim.keymap.set('n', '<leader>H', Telescope.help_tags)
+
+-- Fuzzy find active buffers
+vim.keymap.set('n', "'b", Telescope.buffers)
+
+-- Search for string
+vim.keymap.set('n', "'r", Telescope.live_grep)
+
+-- Fuzzy find changed files in git
+vim.keymap.set('n', "'c", Telescope.git_status)

--- a/nvim/lua/brunocroh/plugins/treesitter.lua
+++ b/nvim/lua/brunocroh/plugins/treesitter.lua
@@ -1,0 +1,29 @@
+require('nvim-treesitter.configs').setup({
+  auto_install = true,
+  ensure_installed = {
+    'c',
+    'lua',
+    'rust',
+    'go',
+    'javascript',
+    'typescript',
+    'tsx',
+    'markdown',
+    'markdown_inline',
+    'html',
+    'css',
+    'json',
+    'bash',
+  },
+  highlight = {
+    enable = true,
+    additional_vim_regex_highlighting = false,
+  },
+  indent = {
+    enable = true,
+  },
+  -- windwp/nvim-ts-autotag
+  autotag = {
+    enable = true,
+  },
+})

--- a/nvim/lua/brunocroh/settings.lua
+++ b/nvim/lua/brunocroh/settings.lua
@@ -1,0 +1,7 @@
+local g = vim.g
+local o = vim.o
+
+vim.wo.wrap = false
+o.termguicolors = true
+o.background = "dark"
+vim.cmd([[colorscheme gruvbox]])


### PR DESCRIPTION
Add Neovim with lua config files

plugins addes:

- packer
- plenary
- gruvbox
- nvim-lualine
- nvim-tree
- nvim-treesitter
- nvim-ts-autotag
- telescope
- telescope-fzf
- telescope-symbols
- emmet-vim
- vim-surround
- completion-nvim
- nvim-lspconfig
- cmp-nvim-lsp
- nvim-cmp
- friendly-snippets
- null-ls
- nvim-autopairs
- mason
- mason-lspconfig
- fidget

Reference:
https://github.com/numToStr/dotfiles
